### PR TITLE
adding beta for tauMethod & parameter switches for function options

### DIFF
--- a/MIMICS_sim_litterbag.R
+++ b/MIMICS_sim_litterbag.R
@@ -71,8 +71,7 @@ MIMICS_LITBAG <- function(forcing_df, litBAG, dailyInput=NA, nspin_yrs=10, nspin
     # For recalc of Tpars from daily forcing data
     if (!is.na(dailyInput)) {
       # Set daily Tpars from daily state variables in "dailyInput" dataframe (added in function arguments)
-      Tpars_mod = calc_Tpars(fWmethod = 0, historic=FALSE, LiDET_fMET=FALSE, #<-- ENSURE these settings match the ss run
-                             ANPP = dailyInput$ANPP[d], 
+      Tpars_mod = calc_Tpars( ANPP = dailyInput$ANPP[d], #<-- ENSURE these settings match the ss run
                              fCLAY = dailyInput$fCLAY[d], 
                              TSOI = dailyInput$TSOI[d], 
                              MAT = dailyInput$MAT[d], 
@@ -252,3 +251,4 @@ ggplot() +
   labs(color="LiDET\nLitter Type") +
   ggtitle("MIMICS Litter Bag Simulation") +
   theme_bw()
+

--- a/MIMICS_steady_state_pools.R
+++ b/MIMICS_steady_state_pools.R
@@ -69,9 +69,7 @@ MIMICS_SS <- function(df){
   # function calculates fMET with LIG_N if provided in input data.
   Tpars <- calc_Tpars_Conly(ANPP=ANPP, fCLAY=fCLAY, TSOI=TSOI, MAT=MAT,     
                             CN=CN, LIG=LIG, LIG_N=LIG_N,
-                            theta_liq=theta_liq, theta_frzn=theta_frzn)  #<---- IMPORTANT USER OPTIONS HERE
-                            #fWmethod=df$fWmethod, historic=df$historic, #<--- Moved to parameter file
-                            #fixed_fMET=df$fixed_fMET, tauMethod=df$tauMethod)
+                            theta_liq=theta_liq, theta_frzn=theta_frzn) 
     
   # Create arrays to hold output
   lit     <- Tpars$I

--- a/MIMICS_steady_state_pools.R
+++ b/MIMICS_steady_state_pools.R
@@ -67,10 +67,11 @@ MIMICS_SS <- function(df){
   # MIMICS MODEL CODE STARTS HERE
   ############################################################
   # function calculates fMET with LIG_N if provided in input data.
-  Tpars <- calc_Tpars_Conly(fWmethod=0, historic=TRUE, LiDET_fMET=FALSE,      #<---- IMPORTANT USER OPTIONS HERE
-                            ANPP=ANPP, fCLAY=fCLAY, TSOI=TSOI, MAT=MAT,
+  Tpars <- calc_Tpars_Conly(ANPP=ANPP, fCLAY=fCLAY, TSOI=TSOI, MAT=MAT,     
                             CN=CN, LIG=LIG, LIG_N=LIG_N,
-                            theta_liq=theta_liq, theta_frzn=theta_frzn)
+                            theta_liq=theta_liq, theta_frzn=theta_frzn)  #<---- IMPORTANT USER OPTIONS HERE
+                            #fWmethod=df$fWmethod, historic=df$historic, #<--- Moved to parameter file
+                            #fixed_fMET=df$fixed_fMET, tauMethod=df$tauMethod)
     
   # Create arrays to hold output
   lit     <- Tpars$I
@@ -99,6 +100,7 @@ MIMICS_SS <- function(df){
   .GlobalEnv$desorb <- Tpars$desorb
   .GlobalEnv$DEsorb <- Tpars$DEsorb
   .GlobalEnv$OXIDAT <- Tpars$OXIDAT
+  .GlobalEnv$beta <- Tpars$beta
   
   # ------------RUN THE MODEL-------------
   test  <- stode(y = Ty, time = 1e7, fun = RXEQ, parms = Tpars, positive = TRUE)
@@ -182,32 +184,29 @@ MIMruns <- LTER %>% split(1:nrow(LTER)) %>% map(~ MIMICS_SS(df=.))
 MIMruns_format <- lapply(MIMruns, MIMICS_SS_format) %>% bind_rows()
 MIMICS_ss_dataset <- LTER[,1:2] %>% cbind(MIMruns_format %>% select(-SITE, -SOC))  # Bind data info columns to MIMICS output
 
-# # View table
-# datatable(MIMICS_ss_dataset %>% mutate_if(is.numeric, round, digits=3))
-# 
-# 
-# # Plot field vs MIMICS SOC
-# #---------------------------------
-# plot_data <- MIMICS_ss_dataset
-# 
-# # Calc SOC vs. MIMSOC r2 and RMSE
-# r2_test <- cor.test(plot_data$SOC, plot_data$MIMSOC)
-# r_val <- round(as.numeric(unlist(r2_test ['estimate'])),2)
-# lb2 <- paste("R^2 == ", r_val)
-# 
-# rmse <- round(rmse(plot_data$SOC, plot_data$MIMSOC),2)
-# 
-# # Plot SOC vs. MIMSOC
-# ggplot(plot_data, aes(x=MIMSOC, y=SOC, color=TSOI)) +
-#   geom_abline(intercept = 0, slope = 1, linetype = "dashed")+
-#   geom_point(size=4, alpha=0.8) +
-#   geom_text(aes(label=paste0(Site)),hjust=-0.2, vjust=0.2) +
-#   annotate("text", label = lb2, x = 2, y = 8.5, size = 4, colour = "black", parse=T) +
-#   annotate("text", label = paste0("RMSE = ", rmse), x = 2, y = 7.4, size = 4, colour = "black") +
-#   ylim(0,10) + xlim(0,10) +
-#   theme_minimal()
-# 
-# # Check against sandbox
+# View table
+datatable(MIMICS_ss_dataset %>% mutate_if(is.numeric, round, digits=3))
+
+# Plot field vs MIMICS SOC
+#---------------------------------
+plot_data <- MIMICS_ss_dataset
+
+# Calc SOC vs. MIMSOC r2 and RMSE
+r2_test <- cor.test(plot_data$SOC, plot_data$MIMSOC)
+r_val <- round(as.numeric(unlist(r2_test ['estimate'])),2)
+lb2 <- paste("R^2 == ", r_val)
+rmse <- round(rmse(plot_data$SOC, plot_data$MIMSOC),2)
+# Plot SOC vs. MIMSOC
+ggplot(plot_data, aes(x=MIMSOC, y=SOC, color=TSOI)) +
+  geom_abline(intercept = 0, slope = 1, linetype = "dashed")+
+  geom_point(size=4, alpha=0.8) +
+  geom_text(aes(label=paste0(Site)),hjust=-0.2, vjust=0.2) +
+  annotate("text", label = lb2, x = 2, y = 8.5, size = 4, colour = "black", parse=T) +
+  annotate("text", label = paste0("RMSE = ", rmse), x = 2, y = 7.4, size = 4, colour = "black") +
+  ylim(0,10) + xlim(0,10) +
+  theme_minimal()
+ 
+# Check against sandbox
 # # Run the sandbox MIMICS script, then run...
 # # plot_data$Wieder_2015_MIMSOC <- MIMSOC
 # # ggplot(plot_data, aes(x=MIMSOC, y=Wieder_2015_MIMSOC)) + geom_point(size=3) +
@@ -216,3 +215,14 @@ MIMICS_ss_dataset <- LTER[,1:2] %>% cbind(MIMruns_format %>% select(-SITE, -SOC)
 # #   ylab("Wieder et al. 2015 - Sandbox\nMIMSOC") +
 # #   theme_minimal()
 
+# quick way to set title for plot below 
+if (.GlobalEnv$beta==1) {
+  gg_title = 'tauMethod = NPP' 
+} else {
+  gg_title = 'tauMethod = beta' 
+}
+
+ggplot(plot_data, aes(x=ANPP, y=MIMMIC, color=TSOI)) +
+  geom_point(size=4, alpha=0.8) +
+  ggtitle(gg_title) +
+  theme_minimal()

--- a/Parameters/MIMICS_parameters_sandbox_20231129.R
+++ b/Parameters/MIMICS_parameters_sandbox_20231129.R
@@ -33,7 +33,7 @@ fW_p1 <- 1.212580 #* 0.6867031  # MSBio new
 fW_p2 <- 2.748028 #* 0.6300376  # MSBio new
 
 #Set default methods
-fWmethod=0.      #0=
+fWmethod=0.      #0-> fW=1, 1->CORPSE, 2->Calibrated 
 historic=FALSE   #modify Vmax based on historic MAT
 fixed_fMET=FALSE #calculate fMET based on litter chemistry
 tauMethod='NPP'  #'NPP' and 'beta' accepted

--- a/Parameters/MIMICS_parameters_sandbox_20231129.R
+++ b/Parameters/MIMICS_parameters_sandbox_20231129.R
@@ -14,7 +14,7 @@ CUE     <- c(0.55, 0.25, 0.75, 0.35)
 tau_r   <- c(0.00052, 0.3)
 tau_K   <- c(0.00024, 0.1)
 Tau_MOD <- c(100, 0.8, 1.2, 2)
-beta    <- 1.5 # only used if tauMethod='beta'
+beta    <- c(1.5) # only used if tauMethod='beta'
 fPHYS_r <- c(0.3, 1.3)
 fPHYS_K <- c(0.2, 0.8)
 fCHEM_r <- c(0.1, -3, 1)

--- a/Parameters/MIMICS_parameters_sandbox_20231129.R
+++ b/Parameters/MIMICS_parameters_sandbox_20231129.R
@@ -14,6 +14,7 @@ CUE     <- c(0.55, 0.25, 0.75, 0.35)
 tau_r   <- c(0.00052, 0.3)
 tau_K   <- c(0.00024, 0.1)
 Tau_MOD <- c(100, 0.8, 1.2, 2)
+beta    <- 1.5 # only used if tauMethod='beta'
 fPHYS_r <- c(0.3, 1.3)
 fPHYS_K <- c(0.2, 0.8)
 fCHEM_r <- c(0.1, -3, 1)
@@ -30,6 +31,12 @@ MICROtoECO <- depth * 1e4 * 1e-3  # mgC/cm3 to g/m2
 # fW coeeficient for Pierson-CORPSE moisture control
 fW_p1 <- 1.212580 #* 0.6867031  # MSBio new
 fW_p2 <- 2.748028 #* 0.6300376  # MSBio new
+
+#Set default methods
+fWmethod=0.      #0=
+historic=FALSE   #modify Vmax based on historic MAT
+fixed_fMET=FALSE #calculate fMET based on litter chemistry
+tauMethod='NPP'  #'NPP' and 'beta' accepted
 
 #Set default multipliers
 Tau_MULT = 1

--- a/RXEQ/RXEQ_ftn.R
+++ b/RXEQ/RXEQ_ftn.R
@@ -14,17 +14,17 @@ RXEQ <- function(t, y, pars) {
     #Flows to and from MIC_1
     LITmin[1] = MIC_1 * VMAX[1] * LIT_1 / (KM[1] + MIC_1)   #MIC_1 decomp of MET lit
     LITmin[2] = MIC_1 * VMAX[2] * LIT_2 / (KM[2] + MIC_1)   #MIC_1 decomp of STRUC lit
-    MICtrn[1] = MIC_1 * tau[1]  * fPHYS[1]                  #MIC_1 turnover to PHYSICAL SOM 
-    MICtrn[2] = MIC_1 * tau[1]  * fCHEM[1]                  #MIC_1 turnover to CHEMICAL SOM  
-    MICtrn[3] = MIC_1 * tau[1]  * fAVAI[1]                  #MIC_1 turnover to AVAILABLE SOM  
+    MICtrn[1] = MIC_1^beta * tau[1]  * fPHYS[1]             #MIC_1 turnover to PHYSICAL SOM 
+    MICtrn[2] = MIC_1^beta * tau[1]  * fCHEM[1]             #MIC_1 turnover to CHEMICAL SOM  
+    MICtrn[3] = MIC_1^beta * tau[1]  * fAVAI[1]             #MIC_1 turnover to AVAILABLE SOM  
     SOMmin[1] = MIC_1 * VMAX[3] * SOM_3 / (KM[3] + MIC_1)   #decomp of SOMa by MIC_1
     
     #Flows to and from MIC_2
     LITmin[3] = MIC_2 * VMAX[4] * LIT_1 / (KM[4] + MIC_2)   #decomp of MET litter
     LITmin[4] = MIC_2 * VMAX[5] * LIT_2 / (KM[5] + MIC_2)   #decomp of SRUCTURAL litter
-    MICtrn[4] = MIC_2 * tau[2]  * fPHYS[2]                  #MIC_2 turnover to PHYSICAL  SOM 
-    MICtrn[5] = MIC_2 * tau[2]  * fCHEM[2]                  #MIC_2 turnover to CHEMICAL  SOM  
-    MICtrn[6] = MIC_2 * tau[2]  * fAVAI[2]                  #MIC_2 turnover to AVAILABLE SOM  
+    MICtrn[4] = MIC_2^beta * tau[2]  * fPHYS[2]             #MIC_2 turnover to PHYSICAL  SOM 
+    MICtrn[5] = MIC_2^beta * tau[2]  * fCHEM[2]             #MIC_2 turnover to CHEMICAL  SOM  
+    MICtrn[6] = MIC_2^beta * tau[2]  * fAVAI[2]             #MIC_2 turnover to AVAILABLE SOM  
     SOMmin[2] = MIC_2 * VMAX[6] * SOM_3 / (KM[6] + MIC_2)   #decomp of SOMa by MIC_2
     
     DEsorb    = SOM_1 * desorb  #* (MIC_1 + MIC_2)  	#desorbtion of PHYS to AVAIL (function of fCLAY)

--- a/calc_Tpars.R
+++ b/calc_Tpars.R
@@ -11,8 +11,6 @@
 # -- fWmethod is describes how to calculate fW 0=none 1=corpse, 2=calibrated 
 # -- historic is a logical for using historic MAT to modify Vslope & Vint
 
-# Todo, put methods on the parameter file ?
-# fWmethod, historic, fixed_fMET, tauMethod
 calc_Tpars_Conly <- function(ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
                              theta_liq=NA, theta_frzn=NA) {
   

--- a/calc_Tpars.R
+++ b/calc_Tpars.R
@@ -11,9 +11,9 @@
 # -- fWmethod is describes how to calculate fW 0=none 1=corpse, 2=calibrated 
 # -- historic is a logical for using historic MAT to modify Vslope & Vint
 
-# TODO add fW calculation to this series of calculations
-calc_Tpars_Conly <- function(fWmethod = 0, historic=FALSE, LiDET_fMET=FALSE, 
-                             ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
+# Todo, put methods on the parameter file ?
+# fWmethod, historic, fixed_fMET, tauMethod
+calc_Tpars_Conly <- function(ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
                              theta_liq=NA, theta_frzn=NA) {
   
   # Set lig:N value if not given
@@ -48,10 +48,10 @@ calc_Tpars_Conly <- function(fWmethod = 0, historic=FALSE, LiDET_fMET=FALSE,
   
 
   # set fMET
-  if(!LiDET_fMET){
+  if(!fixed_fMET){
     fMET  <- fmet_p[1] * (fmet_p[2] - fmet_p[3] * LIG_N)    
   } else {
-    # ONLY for model validation against MIMICS et al. 2015 Sandbox 
+    # Fixed Fmet, ONLY for model validation against MIMICS et al. 2015 Sandbox 
     fMET <- 0.3846423
   }
 
@@ -60,14 +60,22 @@ calc_Tpars_Conly <- function(fWmethod = 0, historic=FALSE, LiDET_fMET=FALSE,
   EST_LIT <- (ANPP / (365*24)) * 1e3 / 1e4
 
   # ------------ calculate time varying parameters ---------------
-
+  # aV = aV*0.3 # increase decay rates
   Vmax     <- exp(TSOI * Vslope + Vint) * aV * fW   #<-- Moisture scalar applied
   Km       <- exp(TSOI * Kslope + Kint) * aK
   
-  Tau_MOD1 <- sqrt(ANPP/Tau_MOD[1])         
+  if (tauMethod == 'NPP') {
+    Tau_MOD1 <- sqrt(ANPP/Tau_MOD[1])         
+    Tau_MOD1[Tau_MOD1 < Tau_MOD[2]] <- Tau_MOD[2]
+    Tau_MOD1[Tau_MOD1 > Tau_MOD[3]] <- Tau_MOD[3] 
+    beta=1 # turns off beta
+  } else if (tauMethod=='beta') {
+    Tau_MOD1 <- 1. # turns off NPP efffects on turnover
+    # Todo, put beta on the parameter file
+    beta=1.5 # use Kat's density dependent function         
+  }
+  
   Tau_MOD2 <- Tau_MOD[4]                        
-  Tau_MOD1[Tau_MOD1 < Tau_MOD[2]] <- Tau_MOD[2]
-  Tau_MOD1[Tau_MOD1 > Tau_MOD[3]] <- Tau_MOD[3] 
   
   tau <- c(tau_r[1]*exp(tau_r[2]*fMET), 
            tau_K[1]*exp(tau_K[2]*fMET))   
@@ -107,7 +115,8 @@ calc_Tpars_Conly <- function(fWmethod = 0, historic=FALSE, LiDET_fMET=FALSE,
   Tpars <- list(I = I, VMAX = VMAX, KM = KM, CUE = CUE,
                  fPHYS = fPHYS, fCHEM = fCHEM, fAVAI = fAVAI, FI = FI, 
                  tau = tau, LITmin = LITmin, SOMmin = SOMmin, MICtrn = MICtrn, 
-                 desorb = desorb, DEsorb = DEsorb, OXIDAT = OXIDAT, KO = KO)
+                 desorb = desorb, DEsorb = DEsorb, OXIDAT = OXIDAT, KO = KO, 
+                 beta=beta)
   
   return(Tpars)
 }

--- a/calc_Tpars.R
+++ b/calc_Tpars.R
@@ -60,7 +60,6 @@ calc_Tpars_Conly <- function(ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
   EST_LIT <- (ANPP / (365*24)) * 1e3 / 1e4
 
   # ------------ calculate time varying parameters ---------------
-  # aV = aV*0.3 # increase decay rates
   Vmax     <- exp(TSOI * Vslope + Vint) * aV * fW   #<-- Moisture scalar applied
   Km       <- exp(TSOI * Kslope + Kint) * aK
   
@@ -71,8 +70,7 @@ calc_Tpars_Conly <- function(ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
     beta=1 # turns off beta
   } else if (tauMethod=='beta') {
     Tau_MOD1 <- 1. # turns off NPP efffects on turnover
-    # Todo, put beta on the parameter file
-    beta=1.5 # use Kat's density dependent function         
+    beta=beta[1] # use Kat's density dependent function         
   }
   
   Tau_MOD2 <- Tau_MOD[4]                        


### PR DESCRIPTION
 This PR creates an option to explore density dependent microbial turnover parameterizations using `tauMethod`.  Specifically this PR:
 
- creates option for applying tau function of NPP (as in Wieder et al. 2015) or 
- density dependent turnover (beta, from [Georgiou et al 2017](https://www.nature.com/articles/s41467-017-01116-z).
 - puts a growing list of method options from calc_Tpars on the parameter file, so we can modify the parameter file, not the function call.
 - addresses #9 by introducing a `fixed_fmet`d option
 
**Notes on results:** when `tauMethod = 'beta'` microbial biomass is much higher, leading to more rapid litter decomposition.  This can be adjusted by modifying kinetics (e.g. reducing `Vint` by 70% of it's default value), but likely warrants further discussion about where we should start our calibration?  Maybe on our Friday calls (if not sooner) with @piersond and @katierocci?
  